### PR TITLE
Update/withdraw for underlying

### DIFF
--- a/contracts/SaveToken.sol
+++ b/contracts/SaveToken.sol
@@ -111,8 +111,6 @@ contract SaveToken is ERC20Extended, Pausable {
         uint256 assetTokens = _delegatecall(StorageLib.assetAdapter(), signature_hold);
         uint256 insuranceTokens = _delegatecall(StorageLib.insuranceAdapter(), signature_buy);
 
-        _mint(msg.sender, amount);
-
         // update asset and insurance token balances
         StorageLib.updateAssetBalance(
             msg.sender, StorageLib.getAssetBalance(msg.sender).add(assetTokens)
@@ -120,6 +118,8 @@ contract SaveToken is ERC20Extended, Pausable {
         StorageLib.updateInsuranceBalance(
             msg.sender, StorageLib.getInsuranceBalance(msg.sender).add(insuranceTokens)
         );
+        
+        _mint(msg.sender, amount);
         
         emit Mint(amount, msg.sender);
 
@@ -213,11 +213,16 @@ contract SaveToken is ERC20Extended, Pausable {
         // amount of the underlying to withdraw
         uint256 underlyingToWithdraw = updatedUnderlyingBalance.sub(initialUnderlyingBalance);
 
+        // update asset and insurance token balances
+        StorageLib.updateAssetBalance(
+            msg.sender, StorageLib.getAssetBalance(msg.sender).sub(assetWithdrawAmount)
+        );
+        StorageLib.updateInsuranceBalance(
+            msg.sender, StorageLib.getInsuranceBalance(msg.sender).sub(insuranceWithdrawAmount)
+        ); 
+
         //transfer underlying to msg.sender
         require(StorageLib.underlyingInstance().transfer(msg.sender, underlyingToWithdraw));
-
-        // update asset and insurance token balances
-        _subtractFromBalances(msg.sender, assetWithdrawAmount, insuranceWithdrawAmount);
 
         emit WithdrawForUnderlyingAsset(amount, msg.sender);
 
@@ -300,18 +305,6 @@ contract SaveToken is ERC20Extended, Pausable {
         );
         StorageLib.updateInsuranceBalance(
             recipient, StorageLib.getInsuranceBalance(recipient).add(insuranceTransferAmount)
-        ); 
-    }
-
-    function _subtractFromBalances(address user, uint256 assetAmount, uint256 insuranceAmount) 
-        internal 
-        {
-        
-        StorageLib.updateAssetBalance(
-            user, StorageLib.getAssetBalance(user).sub(assetAmount)
-        );
-        StorageLib.updateInsuranceBalance(
-            user, StorageLib.getInsuranceBalance(user).sub(insuranceAmount)
         ); 
     }
 

--- a/contracts/adapters/CoverAdapter.sol
+++ b/contracts/adapters/CoverAdapter.sol
@@ -46,8 +46,6 @@ contract CoverAdapter is IInsurance {
         // approve the transfer
         covTokenInstance.approve(address(balancerPool), amount);
 
-        require(isActive() == true, "must not be expired");
-
         // solhint-disable-next-line
         (uint256 tokensOut,) = balancerPool.swapExactAmountIn(
             address(StorageLib.insuranceToken()), // tokenIn
@@ -86,22 +84,6 @@ contract CoverAdapter is IInsurance {
                 amount, // token amount out
                 swapFee
             );
-    }
-
-    /// @dev Check expiration status of insurance token
-    /// @return Returns true if insurance token has NOT expired
-    function isActive() 
-        public
-        view
-        override(IInsurance) 
-        returns (bool) 
-        {
-        //TODO: Cover is a bit unique in how these Cover contracts 
-        // (which are proxies that hold collateral and expiration date info)
-        // deploy CLAIM and NOCLAIM tokens associated with a paritical type of coverage (e.g., covADai)
-        // Not sure how we should handle for this function?
-        ICoverToken covToken = ICoverToken(0x8Ce9E9c8D6Ebb919cA7Db573737D7c4acdd904F8);
-        return block.timestamp < covToken.expirationTimestamp();
     }
 
 }

--- a/contracts/adapters/CoverAdapter.sol
+++ b/contracts/adapters/CoverAdapter.sol
@@ -21,7 +21,7 @@ contract CoverAdapter is IInsurance {
         IBalancerPool balancerPool = IBalancerPool(StorageLib.exchangeFactory());
 
         // approve the transfer
-        underlyingToken.approve(address(balancerPool), amount );
+        underlyingToken.approve(address(balancerPool), amount);
 
         // solhint-disable-next-line
         (uint256 tokensOut,) = balancerPool.swapExactAmountIn(
@@ -39,23 +39,24 @@ contract CoverAdapter is IInsurance {
         override(IInsurance)
         returns (uint256) 
         {
-        address covToken = StorageLib.insuranceToken();
+        IERC20 covTokenInstance = IERC20(StorageLib.insuranceToken());
         IERC20 underlyingToken = IERC20(StorageLib.underlyingToken());
         IBalancerPool balancerPool = IBalancerPool(StorageLib.exchangeFactory());
 
         // approve the transfer
-        underlyingToken.approve(address(balancerPool), amount );
+        covTokenInstance.approve(address(balancerPool), amount);
 
-        require(isActive(), "must not be expired");
+        //TODO: Address whether or not insurnace has expired
+        //require(isActive(), "must not be expired");
 
         // solhint-disable-next-line
         (uint256 tokensOut,) = balancerPool.swapExactAmountIn(
-                address(covToken), // tokenIn
-                amount, // tokenAmountIn
-                address(underlyingToken), // tokenOut
-                1, // minAmountOut
-                type(uint256).max // maxPrice
-            );
+            address(StorageLib.insuranceToken()), // tokenIn
+            amount, // tokenAmountIn
+            address(underlyingToken), // tokenOut
+            1, // minAmountOut
+            type(uint256).max // maxPrice
+        );
         return tokensOut;
     }
 

--- a/contracts/adapters/CoverAdapter.sol
+++ b/contracts/adapters/CoverAdapter.sol
@@ -46,8 +46,7 @@ contract CoverAdapter is IInsurance {
         // approve the transfer
         covTokenInstance.approve(address(balancerPool), amount);
 
-        //TODO: Address whether or not insurnace has expired
-        //require(isActive(), "must not be expired");
+        require(isActive() == true, "must not be expired");
 
         // solhint-disable-next-line
         (uint256 tokensOut,) = balancerPool.swapExactAmountIn(
@@ -92,12 +91,16 @@ contract CoverAdapter is IInsurance {
     /// @dev Check expiration status of insurance token
     /// @return Returns true if insurance token has NOT expired
     function isActive() 
-        public 
+        public
         view
         override(IInsurance) 
         returns (bool) 
         {
-        ICoverToken covToken = ICoverToken(StorageLib.insuranceToken());
+        //TODO: Cover is a bit unique in how these Cover contracts 
+        // (which are proxies that hold collateral and expiration date info)
+        // deploy CLAIM and NOCLAIM tokens associated with a paritical type of coverage (e.g., covADai)
+        // Not sure how we should handle for this function?
+        ICoverToken covToken = ICoverToken(0x8Ce9E9c8D6Ebb919cA7Db573737D7c4acdd904F8);
         return block.timestamp < covToken.expirationTimestamp();
     }
 

--- a/contracts/adapters/OpynAdapter.sol
+++ b/contracts/adapters/OpynAdapter.sol
@@ -44,15 +44,14 @@ contract OpynAdapter is IInsurance {
         // gives uniswap exchange allowance to transfer ocDAI tokens
         require(ocToken.approve(address(ocDaiExchange), amount));
 
-        uint256 underlyingTokens = isActive() ?
+        uint256 underlyingTokens = 
             ocDaiExchange.tokenToTokenSwapInput (
                 amount, // tokens sold
                 1, // min_tokens_bought
                 1, // min eth bought
                 1099511627776, // deadline
                 address(underlyingToken) // token address
-            )
-        : 0;
+            );
         return underlyingTokens;
     }
 
@@ -76,18 +75,6 @@ contract OpynAdapter is IInsurance {
 
         // get the amount of daiTokens that needs to be paid to get the desired ethToPay.
         return underlyingExchange.getTokenToEthOutputPrice(ethToPay);
-    }
-
-    /// @dev Check expiration status of insurance token
-    /// @return Returns true if insurance token has NOT expired
-    function isActive() 
-        public 
-        view
-        override(IInsurance) 
-        returns (bool) 
-        {
-        IOToken ocToken = IOToken(StorageLib.insuranceToken());
-        return !ocToken.hasExpired();
     }
 
     /***************

--- a/contracts/interfaces/IInsurance.sol
+++ b/contracts/interfaces/IInsurance.sol
@@ -6,5 +6,4 @@ interface IInsurance {
     function buyInsurance(uint256 amount) external returns (uint256);
     function sellInsurance(uint256 amount) external returns (uint256);
     function getCostOfInsurance(uint256 amount) external view returns (uint256);
-    function isActive() external returns (bool);
 }

--- a/contracts/interfaces/external/ICoverToken.sol
+++ b/contracts/interfaces/external/ICoverToken.sol
@@ -1,24 +1,6 @@
 // SPDX-License-Identifier: No License
 pragma solidity >=0.6.0 <0.8.0;
 
-/**
- * @title Cover contract interface. See {Cover}.
- * @author crypto-pumpkin@github
- */
 interface ICoverToken {
-
     function expirationTimestamp() external view returns (uint48);
-    function collateral() external view returns (address);
-    function name() external view returns (string memory);
-    function claimNonce() external view returns (uint256);
-
-    function redeemClaim() external;
-    function redeemNoclaim() external;
-    function redeemCollateral(uint256 _amount) external;
-
-    /// @notice access restriction - owner (Protocol)
-    function mint(uint256 _amount, address _receiver) external;
-
-    /// @notice access restriction - dev
-    function setCovTokenSymbol(string calldata _name) external;
 }

--- a/contracts/libraries/StorageLib.sol
+++ b/contracts/libraries/StorageLib.sol
@@ -42,7 +42,7 @@ library StorageLib {
         address _assetToken,
         address _insuranceAdapter,
         address _insuranceToken,
-        address _uniswapFactory,
+        address _exchangeFactory,
         address _saveToken,
         address _admin
     ) internal {
@@ -52,7 +52,7 @@ library StorageLib {
         st.assetToken = _assetToken;
         st.insuranceAdapter = _insuranceAdapter;
         st.insuranceToken = _insuranceToken;
-        st.exchangeFactory = _uniswapFactory;
+        st.exchangeFactory = _exchangeFactory;
         st.saveToken = _saveToken;
         st.admin = _admin;
         st.underlyingInstance = IERC20(_underlyingToken);
@@ -100,8 +100,8 @@ library StorageLib {
         assetToken_ = saveTokenStorage().insuranceToken;
     }
 
-    function exchangeFactory() internal view returns (address uniswapFactory_) {
-        uniswapFactory_ = saveTokenStorage().exchangeFactory;
+    function exchangeFactory() internal view returns (address exchangeFactory_) {
+        exchangeFactory_ = saveTokenStorage().exchangeFactory;
     }
 
     function saveToken() internal view returns (address saveToken_) {

--- a/test/saveToken1.test.js
+++ b/test/saveToken1.test.js
@@ -475,13 +475,8 @@ contract('SaveDAI_Compound_Opyn_Expires_31_Feb_2021', async (accounts) => {
       diffIncDai = cDaiBalanceInitial.sub(cDAIbalanceFinal);
       diffInocDai = ocDaiBalanceInitial.sub(ocDAIbalanceFinal);
 
-      expired = await ocDai.hasExpired();
-      expired ?
-        assert.equal(diffInocDai.toString(), 0) &&
-        assert.equal(diffIncDai.toString(), amount)
-        :
-        assert.equal(diffInocDai.toString(), diffInocDai) &&
-        assert.equal(diffIncDai.toString(), amount);
+      assert.equal(diffInocDai.toString(), diffInocDai) &&
+      assert.equal(diffIncDai.toString(), amount);
     });
     it('should send msg.sender the underlying asset', async () => {
       tokenAmount = await saveDaiInstance.balanceOf(userWallet1);
@@ -510,11 +505,7 @@ contract('SaveDAI_Compound_Opyn_Expires_31_Feb_2021', async (accounts) => {
       const updatedUnderlyingBalance = await dai.balanceOf(userWallet1);
       const diff = (updatedUnderlyingBalance.sub(initialUnderlyingBalance)) / 1e18;
 
-      expired = await ocDai.hasExpired();
-      expired ?
-        assert.approximately(daiReedem, diff, 0.0000009)
-        :
-        assert.approximately(daiBoughtTotal, diff, 0.0000009);
+      assert.approximately(daiBoughtTotal, diff, 0.0000009);
     });
     it('should send msg.sender all of the rewards tokens they\'ve yielded', async () => {
       const userCompBalance = await comp.balanceOf(userWallet1);

--- a/test/saveToken1.test.js
+++ b/test/saveToken1.test.js
@@ -43,7 +43,7 @@ const lensAddress = web3.utils.toChecksumAddress('0xd513d22422a3062Bd342Ae374b4b
 const comptroller = web3.utils.toChecksumAddress('0x3d9819210a31b4961b30ef54be2aed79b9c9cd3b');
 
 // OPYN COMPOUND TOKEN
-contract('SaveToken1: OPYN-COMPOUND', async (accounts) => {
+contract('SaveDAI_Compound_Opyn_Expires_31_Feb_2021', async (accounts) => {
   const owner = accounts[0];
   const userWallet1 = accounts[1];
   const nonUserWallet = accounts[2];
@@ -90,7 +90,7 @@ contract('SaveToken1: OPYN-COMPOUND', async (accounts) => {
       ocDaiAddress,
       uniswapFactoryAddress,
       compFarmer.address,
-      'SaveDAI_Compound_Opyn',
+      'SaveDAI_Compound_Opyn_Expires_31_Feb_2021',
       'SDCO',
       8,
     );
@@ -454,7 +454,7 @@ contract('SaveToken1: OPYN-COMPOUND', async (accounts) => {
     });
     it('revert if the user does not have enough SaveTokens to unbundle', async () => {
       await expectRevert(saveDaiInstance.withdrawForUnderlyingAsset(amount, { from: nonUserWallet }),
-        'must successfully execute delegatecall');
+        'Balance must be greater than 0');
     });
     it('should decrease insuranceTokens from SaveToken contract and assetTokens from farmer', async () => {
       // identify initial balances

--- a/test/saveToken1.test.js
+++ b/test/saveToken1.test.js
@@ -554,7 +554,7 @@ contract('SaveDAI_Compound_Opyn_Expires_31_Feb_2021', async (accounts) => {
       const diff = initialBalance - finalBalance;
       assert.equal(diff, amount);
     });
-    it.skip('should decrease the user\'s assetTokens and insuranceTokens balances', async () => {
+    it('should decrease the user\'s assetTokens and insuranceTokens balances', async () => {
       const initialAssetBalance = await saveDaiInstance.getAssetBalance(userWallet1);
       const initialInsuranceBalance = await saveDaiInstance.getInsuranceBalance(userWallet1);
 
@@ -567,8 +567,8 @@ contract('SaveDAI_Compound_Opyn_Expires_31_Feb_2021', async (accounts) => {
       const assetDiff = initialAssetBalance.sub(finalAssetBalance);
       const insuranceDiff = initialInsuranceBalance.sub(finalInsuranceBalance);
 
-      assert.equal(assetDiff, amount);
-      assert.equal(insuranceDiff, amount);
+      assert.equal(assetDiff.toString(), amount);
+      assert.equal(insuranceDiff.toString(), amount);
     });
   });
   describe('pause and unpause', function () {
@@ -591,7 +591,7 @@ contract('SaveDAI_Compound_Opyn_Expires_31_Feb_2021', async (accounts) => {
     });
     it('should revert if the transfer of rewards is unsuccessful', async () => {
       await expectRevert(saveDaiInstance.withdrawReward({ from: nonUserWallet }),
-        'must successfully execute delegatecall');
+        'rewards balance must be > 0');
     });
     it('should send msg.sender all of the rewards tokens they\'ve yielded', async () => {
       const userCompBalance = await comp.balanceOf(userWallet1);

--- a/test/saveToken2.test.js
+++ b/test/saveToken2.test.js
@@ -33,7 +33,7 @@ const aDaiAddress = '0x028171bCA77440897B824Ca71D1c56caC55b68A3';
 const covADaiAddress = '0xD3866617F3DdC2953A969f831830b60F1603e14b';
 
 // COVER AAVE TOKEN
-contract('SaveToken2: COVER-AAVE', async (accounts) => {
+contract('SaveDAI_Aave_Cover_Expires_31_May_2021', async (accounts) => {
   const owner = accounts[0];
   const userWallet1 = accounts[1];
   const nonUserWallet = accounts[2];
@@ -70,8 +70,8 @@ contract('SaveToken2: COVER-AAVE', async (accounts) => {
       covADaiAddress,
       balancerPool,
       constants.ZERO_ADDRESS,
-      'SaveDAI_Aave_Cover_053121',
-      'SDAC_053121',
+      'SaveDAI_Aave_Cover_Expires_31_May_2021',
+      'SaveDAI_MAY2021',
       18,
     );
     saveDaiAaveAddress = saveToken.logs[0].args.addr;
@@ -363,9 +363,9 @@ contract('SaveToken2: COVER-AAVE', async (accounts) => {
     });
     it('revert if the user does not have enough SaveTokens to unbundle', async () => {
       await expectRevert(saveDaiAaveInstance.withdrawForUnderlyingAsset(amount, { from: nonUserWallet }),
-        'must successfully execute delegatecall');
+        'Balance must be greater than 0');
     });
-    it.only('should decrease insuranceTokens and assetTokens from SaveToken contract', async () => {
+    it.skip('should decrease insuranceTokens and assetTokens from SaveToken contract', async () => {
       // identify initial balances
       const aDAIbalanceInitial = await aDai.balanceOf(saveDaiAaveAddress);
       const covADaibalance = await covADai.balanceOf(saveDaiAaveAddress);
@@ -390,6 +390,7 @@ contract('SaveToken2: COVER-AAVE', async (accounts) => {
       console.log('covADaibalance2: ' + covADaibalance2);
       console.log('daiBalance2: ' + daiBalance2);
       console.log('userWallet2: ' + userWallet2);
+
       /*
       // identify initial balances
       const aDAIbalanceInitial = await aDai.balanceOf(saveDaiAaveAddress);
@@ -417,7 +418,7 @@ contract('SaveToken2: COVER-AAVE', async (accounts) => {
         assert.equal(diffInaDai.toString(), amount);
       */
     });
-    it('should send msg.sender the underlying asset', async () => {
+    it.skip('should send msg.sender the underlying asset', async () => {
       // dai already deposited
       daiAmount = await saveDaiAaveInstance.balanceOf(userWallet1);
       daiAmount = daiAmount.toNumber();
@@ -445,14 +446,14 @@ contract('SaveToken2: COVER-AAVE', async (accounts) => {
         :
         assert.approximately(daiTotal, diff, 0.0000009);
     });
-    it('should emit a WithdrawForUnderlyingAsset event with the msg.sender\'s address and the amount of SaveTokens withdrawn', async () => {
+    it.skip('should emit a WithdrawForUnderlyingAsset event with the msg.sender\'s address and the amount of SaveTokens withdrawn', async () => {
       // unbundle userWallet1's tokens
       const withdrawalReceipt = await saveDaiAaveInstance.withdrawForUnderlyingAsset(amount, { from: userWallet1 });
 
       const wallet = web3.utils.toChecksumAddress(userWallet1);
       expectEvent(withdrawalReceipt, 'WithdrawForUnderlyingAsset', { amount: amount, user: wallet });
     });
-    it('should burn the amount of msg.sender\'s SaveTokens', async () => {
+    it.skip('should burn the amount of msg.sender\'s SaveTokens', async () => {
       const initialBalance = await saveDaiAaveInstance.balanceOf(userWallet1);
       // unbundle userWallet's SaveTokens
       await saveDaiAaveInstance.withdrawForUnderlyingAsset(amount, { from: userWallet1 });
@@ -462,7 +463,7 @@ contract('SaveToken2: COVER-AAVE', async (accounts) => {
       const diff = initialBalance - finalBalance;
       assert.equal(diff, amount);
     });
-    it('should decrease the user\'s assetTokens and insuranceTokens balances', async () => {
+    it.skip('should decrease the user\'s assetTokens and insuranceTokens balances', async () => {
       const initialAssetBalance = await saveDaiAaveInstance.getAssetBalance(userWallet1);
       const initialInsuranceBalance = await saveDaiAaveInstance.getInsuranceBalance(userWallet1);
 

--- a/test/saveToken2.test.js
+++ b/test/saveToken2.test.js
@@ -62,10 +62,6 @@ contract('SaveToken2: COVER-AAVE', async (accounts) => {
     aaveAdapter = await AaveAdapter.new();
     coverAdapter = await CoverAdapter.new();
 
-    aaveAdapterInstance = await AaveAdapter.at(aaveAdapter.address);
-    coverAdapterInstance = await CoverAdapter.at(coverAdapter.address);
-
-
     saveToken = await saveTokenFactory.createSaveToken(
       daiAddress,
       aaveAdapter.address,
@@ -360,7 +356,7 @@ contract('SaveToken2: COVER-AAVE', async (accounts) => {
     });
 
   });
-  describe.skip('withdrawForUnderlyingAsset', function () {
+  describe('withdrawForUnderlyingAsset', function () {
     beforeEach(async () => {
       // Mint saveToken
       await saveDaiAaveInstance.mint(amount, { from: userWallet1 });
@@ -369,7 +365,32 @@ contract('SaveToken2: COVER-AAVE', async (accounts) => {
       await expectRevert(saveDaiAaveInstance.withdrawForUnderlyingAsset(amount, { from: nonUserWallet }),
         'must successfully execute delegatecall');
     });
-    it('should decrease insuranceTokens and assetTokens from SaveToken contract', async () => {
+    it.only('should decrease insuranceTokens and assetTokens from SaveToken contract', async () => {
+      // identify initial balances
+      const aDAIbalanceInitial = await aDai.balanceOf(saveDaiAaveAddress);
+      const covADaibalance = await covADai.balanceOf(saveDaiAaveAddress);
+      const daiBalance = await dai.balanceOf(saveDaiAaveAddress);
+      const userWallet = await dai.balanceOf(userWallet1);
+
+      console.log('aDAIbalanceInitial: ' + aDAIbalanceInitial);
+      console.log('covADaibalance: ' + covADaibalance);
+      console.log('daiBalance: ' + daiBalance);
+      console.log('userWallet: ' + userWallet);
+
+      // unbundle userWallet1's SaveTokens
+      await saveDaiAaveInstance.withdrawForUnderlyingAsset(amount, { from: userWallet1 });
+
+      // identify initial balances
+      const aDAIbalanceInitial2 = await aDai.balanceOf(saveDaiAaveAddress);
+      const covADaibalance2 = await covADai.balanceOf(saveDaiAaveAddress);
+      const daiBalance2 = await dai.balanceOf(saveDaiAaveAddress);
+      const userWallet2 = await dai.balanceOf(userWallet1);
+
+      console.log('aDAIbalanceInitial2: ' + aDAIbalanceInitial2);
+      console.log('covADaibalance2: ' + covADaibalance2);
+      console.log('daiBalance2: ' + daiBalance2);
+      console.log('userWallet2: ' + userWallet2);
+      /*
       // identify initial balances
       const aDAIbalanceInitial = await aDai.balanceOf(saveDaiAaveAddress);
       const ocDAIbalanceInitial = await ocDaiInstance.balanceOf(saveDaiAaveAddress);
@@ -394,6 +415,7 @@ contract('SaveToken2: COVER-AAVE', async (accounts) => {
         :
         assert.equal(diffInocDai.toString(), diffInocDai) &&
         assert.equal(diffInaDai.toString(), amount);
+      */
     });
     it('should send msg.sender the underlying asset', async () => {
       // dai already deposited


### PR DESCRIPTION
- Added require statement to `withdrawForUnderlyingAsset` to ensure user actually has savetokens
- Implemented internal `_calculateRatioAmounts` to calculate ratio of amounts for `_transferTokens` and `withdrawForUnderlyingAsset`
- Updated `withdrawForUnderlyingAsset` to check underlying balance before and after withdrawing assets and selling insurance. This was done because prices could change on exchanges during the insurance sale and before the transfer of the underlying balance (this was the price we used for saveDAI v1, too).
- Updated `_subtractFromBalances` to accept both `assetWithdrawAmount` and `insuranceWithdrawAmount` to account for differences in amounts as a result of the ratios
- Added require statement to `withdrawReward` to ensure user actually has a rewards balance to withdraw
- Removed the requirement statement in the `_delegatecall` for two reasons - 1) it doesn't adequately convey to the user or developer what caused the failure (additional reasons for adding those new require statements to `withdrawForUnderlyingAsset` and `withdrawReward` and 2) sometimes when it would take longer to execute a transaction it would cause a revert
- Regarding `isActive` I think we'll ultimately want to remove that from the `IInsurance` interface because these different protocols will handle that differently as we've seen w/ Cover. Plus that expiry consideration should be dealt w/ on the insurance protocol's end (not to mention the naming conventions which include expiration info)